### PR TITLE
Harden daemon transport and expose lifecycle service APIs

### DIFF
--- a/src/loopback_singleton/__init__.py
+++ b/src/loopback_singleton/__init__.py
@@ -4,6 +4,7 @@ from .errors import (
     DaemonConnectionError,
     HandshakeError,
     LoopbackSingletonError,
+    ProtocolError,
     RemoteError,
 )
 
@@ -11,6 +12,7 @@ __all__ = [
     "local_singleton",
     "LocalSingletonService",
     "LoopbackSingletonError",
+    "ProtocolError",
     "DaemonConnectionError",
     "ConnectionFailedError",
     "HandshakeError",

--- a/src/loopback_singleton/errors.py
+++ b/src/loopback_singleton/errors.py
@@ -17,5 +17,9 @@ class HandshakeError(DaemonConnectionError):
     """Raised when protocol handshake fails."""
 
 
+class ProtocolError(LoopbackSingletonError):
+    """Raised when wire protocol frames/messages are invalid."""
+
+
 class RemoteError(LoopbackSingletonError):
     """Raised when the remote daemon reports an execution error."""

--- a/src/loopback_singleton/proxy.py
+++ b/src/loopback_singleton/proxy.py
@@ -13,8 +13,10 @@ from .transport import recv_message, send_message
 
 
 class Proxy:
-    def __init__(self, sock: socket.socket, serializer_name: str):
+    def __init__(self, sock: socket.socket, serializer_name: str, service_name: str | None = None):
         self._sock = sock
+        self._serializer_name = serializer_name
+        self._service_name = service_name
         self._serializer = get_serializer(serializer_name)
         self._closed = False
         self._io_lock = threading.Lock()
@@ -41,6 +43,11 @@ class Proxy:
 
     def __del__(self) -> None:
         self.close()
+
+    def __repr__(self) -> str:
+        state = "closed" if self._closed else "open"
+        service = self._service_name if self._service_name is not None else "<unknown>"
+        return f"Proxy(service={service!r}, serializer={self._serializer_name!r}, state={state})"
 
     def _call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         if self._closed:

--- a/src/loopback_singleton/transport.py
+++ b/src/loopback_singleton/transport.py
@@ -6,9 +6,11 @@ import socket
 import struct
 from typing import Any
 
+from .errors import ProtocolError
 from .serialization import PickleSerializer
 
 _LEN_STRUCT = struct.Struct("!I")
+MAX_FRAME_BYTES = 16 * 1024 * 1024
 
 
 def _recv_exact(sock: socket.socket, n: int) -> bytes:
@@ -30,5 +32,11 @@ def send_message(sock: socket.socket, obj: Any, serializer: PickleSerializer) ->
 def recv_message(sock: socket.socket, serializer: PickleSerializer) -> Any:
     raw_len = _recv_exact(sock, _LEN_STRUCT.size)
     (payload_len,) = _LEN_STRUCT.unpack(raw_len)
+    if payload_len < 0:
+        raise ProtocolError(f"Invalid frame length: {payload_len}")
+    if payload_len > MAX_FRAME_BYTES:
+        raise ProtocolError(
+            f"Frame too large: {payload_len} bytes exceeds max {MAX_FRAME_BYTES} bytes"
+        )
     payload = _recv_exact(sock, payload_len)
     return serializer.loads(payload)


### PR DESCRIPTION
### Motivation
- Improve robustness of the loopback transport by preventing oversized frames and malformed messages from destabilizing the daemon. 
- Ensure daemon lifecycle behaves deterministically even with idle or stuck clients and provide a small explicit public API for common lifecycle tasks. 
- Add defensive server-side policies (deny private calls) and small UX improvements for client proxies.

### Description
- Add `ProtocolError` and a `MAX_FRAME_BYTES = 16 * 1024 * 1024` cap in `transport.recv_message()` with validation for negative/oversized frame lengths to fail fast and avoid huge allocations. 
- Make daemon client handlers timeout-friendly by introducing `CLIENT_RECV_TIMEOUT`, using `conn.settimeout(...)`, looping on `socket.timeout` during handshake and command receive, and catching `ProtocolError` so the watchdog/idle shutdown can proceed. 
- Enforce server-side policy rejecting `CALL` for method names starting with `_` and expand `PING` response metadata and `SHUTDOWN` handling (accept optional `force`), all in `daemon.py`. 
- Add lifecycle APIs on `LocalSingletonService`: `ensure_started()`, `ping() -> dict`, and `shutdown(force: bool = False)`, and include `service_name` when creating `Proxy` to enable a non-networking `__repr__`. 
- Improve `Proxy.__repr__()` to show `service`, `serializer`, and `state` without performing network I/O. 
- Add integration tests covering oversized frame rejection, stuck-client idle-shutdown robustness, server-side denial of private calls, and lifecycle API behavior, and update `README.md` with scenarios and error-model notes.

### Testing
- Ran the full test suite with the package import path set: `PYTHONPATH=src pytest -q`, result: `24 passed, 2 skipped`.
- Running `pytest -q` without `PYTHONPATH=src` in this environment produced import collection errors due to the test harness not having the `src` path on `sys.path`, which is an environment/setup issue and not a failure of the changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b31c48224832b9782c4e7d34f3be5)