### PR TITLE
tests: consolidate and expand unit coverage across core modules

### DIFF
--- a/tests/fixtures_pkg/services.py
+++ b/tests/fixtures_pkg/services.py
@@ -1,5 +1,6 @@
 class TestCounter:
     __test__ = False
+
     def __init__(self, start: int = 0, step: int = 1) -> None:
         self._value = start
         self._step = step
@@ -17,3 +18,14 @@ class TestCounter:
 
 def make_counter(start: int = 0, step: int = 1) -> TestCounter:
     return TestCounter(start=start, step=step)
+
+
+class DaemonSmokeService:
+    __test__ = False
+
+    def ping(self) -> str:
+        return "smoke"
+
+
+def make_daemon_smoke_service() -> DaemonSmokeService:
+    return DaemonSmokeService()

--- a/tests/test_api_service_unit.py
+++ b/tests/test_api_service_unit.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loopback_singleton.api import LocalSingletonService
+from loopback_singleton.errors import DaemonConnectionError, FactoryMismatchError
+from loopback_singleton.runtime import RuntimePaths
+
+
+@pytest.fixture
+def service() -> LocalSingletonService:
+    return LocalSingletonService(
+        name="svc",
+        factory="fixtures_pkg.services:make_counter",
+        idle_ttl=2.0,
+        serializer="pickle",
+        scope="user",
+        connect_timeout=0.1,
+        start_timeout=0.1,
+    )
+
+
+@pytest.fixture
+def runtime_paths() -> RuntimePaths:
+    base = Path("/tmp/loopback-tests")
+    return RuntimePaths(
+        base_dir=base,
+        runtime_file=base / "runtime.bin",
+        auth_file=base / "auth.bin",
+        lock_file=base / "lock.lock",
+        factory_file=base / "factory.bin",
+    )
+
+
+def test_assert_runtime_factory_match_without_factory_id(service: LocalSingletonService) -> None:
+    service._assert_runtime_factory_match({"host": "127.0.0.1", "port": 1111})
+
+
+def test_assert_runtime_factory_match_same_factory_id(service: LocalSingletonService) -> None:
+    service._assert_runtime_factory_match({"factory_id": service.factory_id})
+
+
+def test_assert_runtime_factory_match_mismatch_raises(service: LocalSingletonService) -> None:
+    with pytest.raises(FactoryMismatchError):
+        service._assert_runtime_factory_match({"factory_id": "another-id"})
+
+
+def test_spawn_daemon_builds_expected_args_and_posix_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_write_factory_payload(paths: RuntimePaths, payload: dict[str, object]) -> None:
+        calls["payload_paths"] = paths
+        calls["payload"] = payload
+
+    def fake_popen(args: list[str], **kwargs: object) -> None:
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return None
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "write_factory_payload", fake_write_factory_payload)
+    monkeypatch.setattr(api, "subprocess", SimpleNamespace(DEVNULL=object(), Popen=fake_popen))
+    monkeypatch.setattr(api.sys, "platform", "linux")
+
+    service._spawn_daemon()
+
+    args = calls["args"]
+    kwargs = calls["kwargs"]
+
+    assert isinstance(args, list)
+    assert "--factory-file" in args
+    assert str(runtime_paths.factory_file) in args
+    assert "--scope" in args and "user" in args
+    assert "--serializer" in args and "pickle" in args
+    assert kwargs["start_new_session"] is True
+    assert "creationflags" not in kwargs
+
+
+def test_spawn_daemon_windows_uses_creationflags(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_popen(args: list[str], **kwargs: object) -> None:
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return None
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "write_factory_payload", lambda *_: None)
+    monkeypatch.setattr(api.sys, "platform", "win32")
+    monkeypatch.setattr(api.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x200, raising=False)
+    monkeypatch.setattr(api.subprocess, "DETACHED_PROCESS", 0x008, raising=False)
+    monkeypatch.setattr(api.subprocess, "Popen", fake_popen)
+
+    service._spawn_daemon()
+
+    kwargs = calls["kwargs"]
+    assert kwargs["creationflags"] == 0x200 | 0x008
+    assert "start_new_session" not in kwargs
+
+
+def test_connect_or_spawn_primary_connect_success_without_lock_or_spawn(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    sock = object()
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "ensure_auth_token", lambda *_: "token")
+    monkeypatch.setattr(service, "_connect_once", lambda: sock)
+    monkeypatch.setattr(service, "_spawn_daemon", lambda: (_ for _ in ()).throw(AssertionError("spawn called")))
+    monkeypatch.setattr(api, "FileLock", lambda *_: (_ for _ in ()).throw(AssertionError("lock used")))
+
+    assert service._connect_or_spawn() is sock
+
+
+def test_connect_or_spawn_first_fail_then_success_under_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    state = {"calls": 0, "entered": False}
+    expected_sock = object()
+
+    class DummyLock:
+        def __enter__(self) -> None:
+            state["entered"] = True
+            return None
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    def fake_connect_once() -> object:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("first connect fail")
+        return expected_sock
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "ensure_auth_token", lambda *_: "token")
+    monkeypatch.setattr(api, "FileLock", lambda *_: DummyLock())
+    monkeypatch.setattr(service, "_connect_once", fake_connect_once)
+    monkeypatch.setattr(service, "_spawn_daemon", lambda: (_ for _ in ()).throw(AssertionError("unexpected spawn")))
+    monkeypatch.setattr(api, "remove_runtime", lambda *_: (_ for _ in ()).throw(AssertionError("unexpected cleanup")))
+
+    assert service._connect_or_spawn() is expected_sock
+    assert state == {"calls": 2, "entered": True}
+
+
+def test_connect_or_spawn_timeout_raises_last_error_text(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    attempts = {"count": 0}
+
+    class DummyLock:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    def fake_connect_once() -> object:
+        attempts["count"] += 1
+        if attempts["count"] <= 2:
+            raise RuntimeError("initial fail")
+        raise ValueError("boom-last")
+
+    import loopback_singleton.api as api
+
+    ticks = iter([0.0, 0.01, 0.02, 0.2])
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "ensure_auth_token", lambda *_: "token")
+    monkeypatch.setattr(api, "FileLock", lambda *_: DummyLock())
+    monkeypatch.setattr(api, "remove_runtime", lambda *_: None)
+    monkeypatch.setattr(service, "_spawn_daemon", lambda: None)
+    monkeypatch.setattr(service, "_connect_once", fake_connect_once)
+    monkeypatch.setattr(api.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(api.time, "sleep", lambda *_: None)
+
+    with pytest.raises(DaemonConnectionError, match="boom-last"):
+        service._connect_or_spawn()
+
+
+def test_connect_or_spawn_timeout_without_last_error_details(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    attempts = {"count": 0}
+
+    class DummyLock:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    def fake_connect_once() -> object:
+        attempts["count"] += 1
+        raise RuntimeError("pre-loop failure")
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(service, "start_timeout", 0.0)
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "ensure_auth_token", lambda *_: "token")
+    monkeypatch.setattr(api, "FileLock", lambda *_: DummyLock())
+    monkeypatch.setattr(api, "remove_runtime", lambda *_: None)
+    monkeypatch.setattr(service, "_spawn_daemon", lambda: None)
+    monkeypatch.setattr(service, "_connect_once", fake_connect_once)
+    monkeypatch.setattr(api.time, "time", lambda: 10.0)
+
+    with pytest.raises(DaemonConnectionError, match="no error details"):
+        service._connect_or_spawn()
+
+
+def test_shutdown_raises_on_bad_response(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+) -> None:
+    events: list[tuple[object, tuple[object, ...], object]] = []
+
+    class DummySock:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    sock = DummySock()
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(service, "_connect_once", lambda: sock)
+    monkeypatch.setattr(api, "get_serializer", lambda *_: object())
+    monkeypatch.setattr(api, "send_message", lambda s, msg, ser: events.append((s, msg, ser)))
+    monkeypatch.setattr(api, "recv_message", lambda *_: ("ERR", "fail"))
+
+    with pytest.raises(DaemonConnectionError, match="Bad shutdown response"):
+        service.shutdown()
+
+    assert sock.closed is True
+    assert events and events[0][1] == ("SHUTDOWN", False)
+
+
+def test_shutdown_forces_runtime_cleanup_after_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    runtime_paths: RuntimePaths,
+) -> None:
+    class DummySock:
+        def close(self) -> None:
+            return None
+
+    import loopback_singleton.api as api
+
+    removed = {"called": False}
+    ticks = iter([0.0, 0.01, 0.03, 0.25])
+
+    monkeypatch.setattr(service, "_connect_once", lambda: DummySock())
+    monkeypatch.setattr(api, "get_serializer", lambda *_: object())
+    monkeypatch.setattr(api, "send_message", lambda *_: None)
+    monkeypatch.setattr(api, "recv_message", lambda *_: ("OK", "done"))
+    monkeypatch.setattr(api, "get_runtime_paths", lambda **_: runtime_paths)
+    monkeypatch.setattr(api, "read_runtime", lambda *_: {"alive": True})
+    monkeypatch.setattr(api, "remove_runtime", lambda *_: removed.update(called=True))
+    monkeypatch.setattr(api.time, "time", lambda: next(ticks))
+    monkeypatch.setattr(api.time, "sleep", lambda *_: None)
+
+    service.shutdown()
+
+    assert removed["called"] is True
+
+
+@pytest.mark.parametrize("resp", [("ERR", {}), ("OK", "not-a-dict")])
+def test_ping_invalid_response_raises_daemon_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+    service: LocalSingletonService,
+    resp: tuple[object, object],
+) -> None:
+    class DummySock:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    sock = DummySock()
+
+    import loopback_singleton.api as api
+
+    monkeypatch.setattr(service, "_connect_or_spawn", lambda: sock)
+    monkeypatch.setattr(api, "get_serializer", lambda *_: object())
+    monkeypatch.setattr(api, "send_message", lambda *_: None)
+    monkeypatch.setattr(api, "recv_message", lambda *_: resp)
+
+    with pytest.raises(DaemonConnectionError, match="Bad ping response"):
+        service.ping()
+
+    assert sock.closed is True

--- a/tests/test_daemon_startup.py
+++ b/tests/test_daemon_startup.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+import pickle
+import socket
+import sys
+import time
+import uuid
+from multiprocessing import get_context
+from pathlib import Path
+
+import pytest
+
+from loopback_singleton.daemon import _load_factory_startup, main, run_daemon
+from loopback_singleton.runtime import ensure_auth_token, get_runtime_paths, remove_runtime, write_factory_payload
+from loopback_singleton.serialization import get_serializer
+from loopback_singleton.transport import recv_message, send_message
+from loopback_singleton.version import PROTOCOL_VERSION
+
+TESTS_DIR = Path(__file__).parent
+os.environ["PYTHONPATH"] = (
+    f"{TESTS_DIR}{os.pathsep}{os.environ.get('PYTHONPATH', '')}".rstrip(os.pathsep)
+)
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+
+def _write_payload_file(path: Path, payload: dict[object, object]) -> None:
+    with path.open("wb") as f:
+        pickle.dump(payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def test_load_factory_startup_valid_payload_returns_values(tmp_path: Path) -> None:
+    payload_file = tmp_path / "factory.bin"
+    payload = {
+        "factory_import": "fixtures_pkg.services:make_daemon_smoke_service",
+        "factory_args": (1, 2),
+        "factory_kwargs": {"x": 3},
+    }
+    _write_payload_file(payload_file, payload)
+
+    factory_import, args, kwargs, factory_id = _load_factory_startup(str(payload_file))
+
+    assert factory_import == payload["factory_import"]
+    assert args == payload["factory_args"]
+    assert kwargs == payload["factory_kwargs"]
+    assert isinstance(factory_id, str)
+    assert factory_id
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_message"),
+    [
+        ("factory_import", 123, "factory_import must be present in factory payload"),
+        ("factory_args", [1], "factory_args must be a tuple"),
+        ("factory_kwargs", [("x", 1)], "factory_kwargs must be a dict"),
+    ],
+)
+def test_load_factory_startup_invalid_types_raise_value_error(
+    tmp_path: Path,
+    field: str,
+    value: object,
+    expected_message: str,
+) -> None:
+    payload_file = tmp_path / "factory.bin"
+    payload: dict[str, object] = {
+        "factory_import": "fixtures_pkg.services:make_daemon_smoke_service",
+        "factory_args": (),
+        "factory_kwargs": {},
+    }
+    payload[field] = value
+    _write_payload_file(payload_file, payload)
+
+    with pytest.raises(ValueError, match=expected_message):
+        _load_factory_startup(str(payload_file))
+
+
+def test_main_passes_cli_args_to_run_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run_daemon(**kwargs) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "daemon.py",
+            "--name",
+            "svc-name",
+            "--factory-file",
+            "/tmp/factory.bin",
+            "--idle-ttl",
+            "3.5",
+            "--serializer",
+            "json",
+            "--scope",
+            "user",
+        ],
+    )
+    monkeypatch.setattr("loopback_singleton.daemon.run_daemon", fake_run_daemon)
+
+    main()
+
+    assert calls == [
+        {
+            "name": "svc-name",
+            "factory_file": "/tmp/factory.bin",
+            "idle_ttl": 3.5,
+            "serializer_name": "json",
+            "scope": "user",
+        }
+    ]
+
+
+def test_run_daemon_unknown_message_type_returns_error() -> None:
+    name = f"daemon-smoke-{uuid.uuid4().hex}"
+    paths = get_runtime_paths(name)
+    token = ensure_auth_token(paths)
+    write_factory_payload(
+        paths,
+        {
+            "factory_import": "fixtures_pkg.services:make_daemon_smoke_service",
+            "factory_args": (),
+            "factory_kwargs": {},
+        },
+    )
+
+    ctx = get_context("spawn")
+    process = ctx.Process(
+        target=run_daemon,
+        kwargs={
+            "name": name,
+            "factory_file": str(paths.factory_file),
+            "idle_ttl": 5.0,
+            "serializer_name": "pickle",
+            "scope": "user",
+        },
+    )
+    process.start()
+
+    serializer = get_serializer("pickle")
+
+    try:
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not paths.runtime_file.exists():
+            time.sleep(0.05)
+        assert paths.runtime_file.exists(), "runtime file was not created"
+
+        runtime = pickle.loads(paths.runtime_file.read_bytes())
+
+        with socket.create_connection((runtime["host"], runtime["port"]), timeout=2.0) as sock:
+            send_message(sock, ("HELLO", PROTOCOL_VERSION, token), serializer)
+            assert recv_message(sock, serializer)[0] == "OK"
+
+            send_message(sock, ("UNKNOWN",), serializer)
+            status, payload = recv_message(sock, serializer)
+            assert status == "ERR"
+            assert "unknown message type: UNKNOWN" in payload
+
+            send_message(sock, ("SHUTDOWN", True), serializer)
+            assert recv_message(sock, serializer)[0] == "OK"
+
+        process.join(timeout=5)
+        assert process.exitcode == 0
+    finally:
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=5)
+        remove_runtime(paths)

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from loopback_singleton.locking import FileLock
+
+
+def test_file_lock_creates_parent_dirs_and_lock_file(tmp_path: Path) -> None:
+    path = tmp_path / "nested/lockfile.lock"
+
+    assert not path.parent.exists()
+    assert not path.exists()
+
+    with FileLock(path):
+        assert path.parent.exists()
+        assert path.exists()
+
+
+def test_file_lock_releases_lock_after_context_exit(tmp_path: Path) -> None:
+    path = tmp_path / "nested/lockfile.lock"
+
+    with FileLock(path):
+        assert path.exists()
+
+    with FileLock(path):
+        assert path.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only chmod path")
+def test_file_lock_ignores_chmod_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    path = tmp_path / "nested/lockfile.lock"
+
+    def _raise_chmod_error(_path: os.PathLike[str] | str, _mode: int) -> None:
+        raise OSError("chmod failed")
+
+    monkeypatch.setattr(os, "chmod", _raise_chmod_error)
+
+    with FileLock(path):
+        assert path.exists()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from loopback_singleton.errors import DaemonConnectionError, RemoteError
+from loopback_singleton.proxy import Proxy
+
+
+def _make_proxy() -> tuple[Proxy, socket.socket]:
+    sock, peer = socket.socketpair()
+    return Proxy(sock=sock, serializer_name="pickle", service_name="svc"), peer
+
+
+def test_close_is_idempotent() -> None:
+    proxy, peer = _make_proxy()
+    try:
+        proxy.close()
+        proxy.close()
+        assert proxy._closed is True
+    finally:
+        peer.close()
+
+
+def test_context_manager_and_repr_states() -> None:
+    proxy, peer = _make_proxy()
+    try:
+        with proxy as managed:
+            assert managed is proxy
+            assert "state=open" in repr(proxy)
+        assert "state=closed" in repr(proxy)
+    finally:
+        peer.close()
+
+
+@pytest.mark.parametrize(
+    ("response", "expected", "error"),
+    [
+        (("OK", {"x": 1}), {"x": 1}, None),
+        (("ERR", "boom"), None, RemoteError),
+        (("MAYBE", "?"), None, DaemonConnectionError),
+    ],
+)
+def test_call_handles_status_responses(monkeypatch, response, expected, error) -> None:
+    proxy, peer = _make_proxy()
+    calls: list[tuple] = []
+
+    def fake_send(sock, payload, serializer):
+        calls.append(payload)
+
+    def fake_recv(sock, serializer):
+        return response
+
+    monkeypatch.setattr("loopback_singleton.proxy.send_message", fake_send)
+    monkeypatch.setattr("loopback_singleton.proxy.recv_message", fake_recv)
+
+    try:
+        if error is None:
+            assert proxy._call("sum", 1, b=2) == expected
+        else:
+            with pytest.raises(error):
+                proxy._call("sum", 1, b=2)
+        assert calls == [("CALL", "sum", (1,), {"b": 2})]
+    finally:
+        proxy.close()
+        peer.close()
+
+
+@pytest.mark.parametrize("method_name", ["_call", "ping_daemon"])
+@pytest.mark.parametrize("failing_fn", ["send", "recv"])
+def test_oserror_is_wrapped_as_connection_error(monkeypatch, method_name: str, failing_fn: str) -> None:
+    proxy, peer = _make_proxy()
+
+    def fake_send(sock, payload, serializer):
+        if failing_fn == "send":
+            raise OSError("socket write failed")
+
+    def fake_recv(sock, serializer):
+        if failing_fn == "recv":
+            raise OSError("socket read failed")
+        return ("OK", {"alive": True})
+
+    monkeypatch.setattr("loopback_singleton.proxy.send_message", fake_send)
+    monkeypatch.setattr("loopback_singleton.proxy.recv_message", fake_recv)
+
+    try:
+        method = getattr(proxy, method_name)
+        if method_name == "_call":
+            with pytest.raises(DaemonConnectionError, match="socket"):
+                method("work")
+        else:
+            with pytest.raises(DaemonConnectionError, match="socket"):
+                method()
+    finally:
+        proxy.close()
+        peer.close()
+
+
+def test_getattr_private_name_raises_attribute_error() -> None:
+    proxy, peer = _make_proxy()
+    try:
+        with pytest.raises(AttributeError):
+            proxy.__getattr__("_hidden")
+    finally:
+        proxy.close()
+        peer.close()
+
+
+def test_getattr_returns_callable_routed_to_call(monkeypatch) -> None:
+    proxy, peer = _make_proxy()
+    observed: dict[str, object] = {}
+
+    def fake_call(method_name, *args, **kwargs):
+        observed["method_name"] = method_name
+        observed["args"] = args
+        observed["kwargs"] = kwargs
+        return "result"
+
+    monkeypatch.setattr(proxy, "_call", fake_call)
+
+    try:
+        fn = proxy.compute
+        assert callable(fn)
+        assert fn(1, test=True) == "result"
+        assert observed == {
+            "method_name": "compute",
+            "args": (1,),
+            "kwargs": {"test": True},
+        }
+    finally:
+        proxy.close()
+        peer.close()
+
+
+@pytest.mark.parametrize("method_name", ["_call", "ping_daemon"])
+def test_closed_proxy_methods_raise_connection_error(method_name: str) -> None:
+    proxy, peer = _make_proxy()
+    proxy._closed = True
+    try:
+        method = getattr(proxy, method_name)
+        with pytest.raises(DaemonConnectionError, match="^Proxy is closed$"):
+            if method_name == "_call":
+                method("method")
+            else:
+                method()
+    finally:
+        peer.close()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,10 +1,103 @@
 from __future__ import annotations
 
+import os
+import pickle
+
 import pytest
 
-from loopback_singleton.runtime import get_runtime_dir
+from loopback_singleton.runtime import (
+    RuntimePaths,
+    ensure_auth_token,
+    get_runtime_dir,
+    read_factory_payload,
+    read_factory_payload_file,
+    read_runtime,
+    remove_runtime,
+    write_factory_payload,
+    write_runtime,
+)
+
+
+def _make_paths(tmp_path) -> RuntimePaths:
+    base_dir = tmp_path / "runtime"
+    return RuntimePaths(
+        base_dir=base_dir,
+        runtime_file=base_dir / "runtime.bin",
+        auth_file=base_dir / "auth.bin",
+        lock_file=base_dir / "lockfile.lock",
+        factory_file=base_dir / "factory.bin",
+    )
 
 
 def test_get_runtime_dir_system_scope_not_implemented() -> None:
     with pytest.raises(NotImplementedError, match="Only scope='user'"):
         get_runtime_dir(name="x", scope="system")
+
+
+def test_runtime_read_write_round_trip(tmp_path) -> None:
+    paths = _make_paths(tmp_path)
+    runtime_info = {"port": 9911, "factory": "pkg:callable", "ready": True}
+
+    write_runtime(paths, runtime_info)
+
+    assert read_runtime(paths) == runtime_info
+
+
+def test_remove_runtime_removes_runtime_and_factory_files_and_is_idempotent(tmp_path) -> None:
+    paths = _make_paths(tmp_path)
+    paths.base_dir.mkdir(parents=True)
+
+    for file_path in (
+        paths.runtime_file,
+        paths.runtime_file.with_suffix(".tmp"),
+        paths.factory_file,
+        paths.factory_file.with_suffix(".tmp"),
+    ):
+        file_path.write_bytes(b"payload")
+
+    remove_runtime(paths)
+
+    assert not paths.runtime_file.exists()
+    assert not paths.runtime_file.with_suffix(".tmp").exists()
+    assert not paths.factory_file.exists()
+    assert not paths.factory_file.with_suffix(".tmp").exists()
+
+    remove_runtime(paths)
+
+
+def test_factory_payload_round_trip_for_both_readers(tmp_path) -> None:
+    paths = _make_paths(tmp_path)
+    payload = {"factory": "pkg:make", "args": [1, 2], "kwargs": {"debug": True}}
+
+    write_factory_payload(paths, payload)
+
+    assert read_factory_payload(paths) == payload
+    assert read_factory_payload_file(paths.factory_file) == payload
+
+
+@pytest.mark.parametrize("invalid_payload", [["not", "a", "dict"], "not-a-dict"])
+def test_factory_payload_readers_raise_for_non_dict_payload(tmp_path, invalid_payload) -> None:
+    paths = _make_paths(tmp_path)
+    paths.base_dir.mkdir(parents=True)
+    with paths.factory_file.open("wb") as f:
+        pickle.dump(invalid_payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    with pytest.raises(ValueError, match="Factory payload must be a dictionary"):
+        read_factory_payload(paths)
+
+    with pytest.raises(ValueError, match="Factory payload must be a dictionary"):
+        read_factory_payload_file(paths.factory_file)
+
+
+def test_ensure_auth_token_reads_existing_file_when_open_raises_file_exists(tmp_path, monkeypatch) -> None:
+    paths = _make_paths(tmp_path)
+    paths.base_dir.mkdir(parents=True)
+    expected_token = "already-exists-token"
+    paths.auth_file.write_text(expected_token, encoding="utf-8")
+
+    def _raise_file_exists(*_args, **_kwargs):
+        raise FileExistsError
+
+    monkeypatch.setattr(os, "open", _raise_file_exists)
+
+    assert ensure_auth_token(paths) == expected_token

--- a/tests/test_serialization_and_exports.py
+++ b/tests/test_serialization_and_exports.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import loopback_singleton
+from loopback_singleton.errors import (
+    ConnectionFailedError,
+    DaemonConnectionError,
+    FactoryMismatchError,
+    HandshakeError,
+    LoopbackSingletonError,
+    ProtocolError,
+    RemoteError,
+)
+from loopback_singleton.serialization import PickleSerializer, get_serializer
+
+
+def test_pickle_serializer_round_trip_for_nested_structures() -> None:
+    serializer = PickleSerializer()
+    payload = {
+        "items": [
+            {"name": "alpha", "values": [1, 2, 3]},
+            {"name": "beta", "metadata": {"enabled": True, "ratio": 0.5}},
+        ],
+        "config": {
+            "retries": 3,
+            "backoff": (0.1, 0.2, 0.4),
+            "tags": {"region": "eu", "service": "worker"},
+        },
+        "flags": {"debug": False, "dry_run": True},
+    }
+
+    encoded = serializer.dumps(payload)
+    decoded = serializer.loads(encoded)
+
+    assert decoded == payload
+
+
+def test_get_serializer_pickle_returns_named_serializer() -> None:
+    serializer = get_serializer("pickle")
+
+    assert serializer.name == "pickle"
+
+
+def test_public_exports_and_root_exception_accessibility() -> None:
+    expected_exports = [
+        "local_singleton",
+        "LocalSingletonService",
+        "LoopbackSingletonError",
+        "ProtocolError",
+        "DaemonConnectionError",
+        "ConnectionFailedError",
+        "FactoryMismatchError",
+        "HandshakeError",
+        "RemoteError",
+    ]
+
+    assert loopback_singleton.__all__ == expected_exports
+
+    assert loopback_singleton.LoopbackSingletonError is LoopbackSingletonError
+    assert loopback_singleton.ProtocolError is ProtocolError
+    assert loopback_singleton.DaemonConnectionError is DaemonConnectionError
+    assert loopback_singleton.ConnectionFailedError is ConnectionFailedError
+    assert loopback_singleton.FactoryMismatchError is FactoryMismatchError
+    assert loopback_singleton.HandshakeError is HandshakeError
+    assert loopback_singleton.RemoteError is RemoteError

--- a/tests/test_transport_unit.py
+++ b/tests/test_transport_unit.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from loopback_singleton import transport
+from loopback_singleton.errors import ProtocolError
+from loopback_singleton.serialization import PickleSerializer
+
+
+class SequenceRecvSocket:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    def recv(self, n: int, flags: int = 0) -> bytes:  # noqa: ARG002
+        if not self._chunks:
+            return b""
+        chunk = self._chunks.pop(0)
+        if len(chunk) <= n:
+            return chunk
+        self._chunks.insert(0, chunk[n:])
+        return chunk[:n]
+
+
+class BufferSocket:
+    def __init__(self, data: bytes, timeout: float | None = None) -> None:
+        self._buffer = bytearray(data)
+        self._timeout = timeout
+        self.peek_calls = 0
+
+    def recv(self, n: int, flags: int = 0) -> bytes:
+        if flags == socket.MSG_PEEK:
+            self.peek_calls += 1
+            return bytes(self._buffer[:n])
+        chunk = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return chunk
+
+    def gettimeout(self) -> float | None:
+        return self._timeout
+
+    def settimeout(self, timeout: float | None) -> None:
+        self._timeout = timeout
+
+    def setblocking(self, flag: bool) -> None:  # noqa: ARG002
+        return None
+
+
+class ProbeSocket:
+    def __init__(self, *, timeout: float | None, recv_result: bytes | Exception) -> None:
+        self._timeout = timeout
+        self._recv_result = recv_result
+        self.settimeout_calls: list[float | None] = []
+        self.setblocking_calls: list[bool] = []
+
+    def gettimeout(self) -> float | None:
+        return self._timeout
+
+    def settimeout(self, timeout: float | None) -> None:
+        self._timeout = timeout
+        self.settimeout_calls.append(timeout)
+
+    def setblocking(self, flag: bool) -> None:
+        self.setblocking_calls.append(flag)
+
+    def recv(self, n: int, flags: int = 0) -> bytes:  # noqa: ARG002
+        if isinstance(self._recv_result, Exception):
+            raise self._recv_result
+        return self._recv_result
+
+
+def test_recv_exact_collects_data_across_multiple_recv_calls() -> None:
+    sock = SequenceRecvSocket([b"ab", b"cd", b"ef"])
+
+    result = transport._recv_exact(sock, 6)
+
+    assert result == b"abcdef"
+
+
+def test_recv_exact_raises_connection_error_when_socket_closes() -> None:
+    sock = SequenceRecvSocket([b"ab", b""])
+
+    with pytest.raises(ConnectionError, match="Socket closed while receiving"):
+        transport._recv_exact(sock, 3)
+
+
+def test_recv_message_decodes_valid_frame() -> None:
+    serializer = PickleSerializer()
+    payload = serializer.dumps({"ok": True, "value": 7})
+    frame = transport._LEN_STRUCT.pack(len(payload)) + payload
+    sock = SequenceRecvSocket([frame[:2], frame[2:6], frame[6:]])
+
+    result = transport.recv_message(sock, serializer)
+
+    assert result == {"ok": True, "value": 7}
+
+
+def test_recv_message_raises_protocol_error_for_too_large_frame() -> None:
+    serializer = PickleSerializer()
+    oversized_len = transport.MAX_FRAME_BYTES + 1
+    sock = SequenceRecvSocket([transport._LEN_STRUCT.pack(oversized_len)])
+
+    with pytest.raises(ProtocolError, match="Frame too large"):
+        transport.recv_message(sock, serializer)
+
+
+def test_recv_message_timeout_returns_none_when_select_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    serializer = PickleSerializer()
+    sock = BufferSocket(b"")
+    monkeypatch.setattr(transport.select, "select", lambda r, w, x, t: ([], [], []))
+
+    result = transport.recv_message_timeout(sock, serializer, timeout=0.1)
+
+    assert result is None
+
+
+def test_recv_message_timeout_reads_full_message_after_peek(monkeypatch: pytest.MonkeyPatch) -> None:
+    serializer = PickleSerializer()
+    payload = serializer.dumps(("pong", 42))
+    frame = transport._LEN_STRUCT.pack(len(payload)) + payload
+    sock = BufferSocket(frame)
+
+    monkeypatch.setattr(transport.select, "select", lambda r, w, x, t: ([sock], [], []))
+
+    result = transport.recv_message_timeout(sock, serializer, timeout=0.5)
+
+    assert result == ("pong", 42)
+    assert sock.peek_calls >= 2
+    assert sock.recv(1) == b""
+
+
+def test_peer_disconnected_fallback_returns_false_on_blocking_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(transport, "_HAS_POLL", False)
+    sock = ProbeSocket(timeout=3.0, recv_result=BlockingIOError())
+
+    assert transport._peer_disconnected(sock) is False
+
+
+def test_peer_disconnected_fallback_returns_true_on_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(transport, "_HAS_POLL", False)
+    sock = ProbeSocket(timeout=4.0, recv_result=OSError("boom"))
+
+    assert transport._peer_disconnected(sock) is True
+
+
+def test_peer_disconnected_fallback_returns_true_on_empty_peek_and_restores_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(transport, "_HAS_POLL", False)
+    sock = ProbeSocket(timeout=5.0, recv_result=b"")
+
+    assert transport._peer_disconnected(sock) is True
+    assert sock.setblocking_calls == [False]
+    assert sock.settimeout_calls == [5.0]
+    assert sock.gettimeout() == 5.0


### PR DESCRIPTION
### Motivation
- Unify and reconcile multiple test additions into a single consistent suite to increase confidence across core modules.
- Broaden unit coverage for Proxy, transport, runtime, service orchestration, daemon startup and serialization behaviors.
- Fix a malformed test snippet in the locking tests and harmonize fixtures used by daemon tests.

### Description
- Added focused unit tests for `Proxy` covering idempotent `close`, context-manager/repr state, `_call` routing, `OSError` wrapping, and closed-state guards (`tests/test_proxy.py`).
- Added `FileLock` tests for creating parent dirs/lockfile, lock release, and POSIX `chmod` error tolerance (`tests/test_locking.py`).
- Expanded runtime helper tests for `write/read_runtime`, `remove_runtime` idempotency, factory payload readers/validation, and `ensure_auth_token` race fallback (`tests/test_runtime.py`).
- Added unit tests for `LocalSingletonService` to validate factory-id matching, daemon spawn args for POSIX/Windows, `connect_or_spawn` decision branches, timeouts, and `ping`/`shutdown` behavior (`tests/test_api_service_unit.py`).
- Added transport-level tests for `_recv_exact`, frame parsing/oversize detection, `recv_message_timeout` behavior, and poll-less `_peer_disconnected` fallback/restoration (`tests/test_transport_unit.py`).
- Added daemon startup/CLI and integration-smoke tests for `_load_factory_startup`, `main()` argument wiring, and unknown-message handling in `run_daemon` (`tests/test_daemon_startup.py`).
- Added serialization round-trip and package export tests and extended test fixtures with a lightweight daemon smoke service (`tests/test_serialization_and_exports.py`, `tests/fixtures_pkg/services.py`).
- No production code was modified; only tests and test fixtures were added/updated, and a malformed test fragment was corrected.

### Testing
- Ran the full test suite with `PYTHONPATH=src pytest -q` and observed `95 passed, 2 skipped` indicating the new tests integrate successfully with the current codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c17c68904832bb413db937fe3a64f)